### PR TITLE
support taps on mobile devices

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -44,6 +44,13 @@ var DrawRectangle = {
       rectangle: rectangle
     };
   },
+  // support mobile taps
+  onTap: function onTap(state, e) {
+    // emulate 'move mouse' to update feature coords
+    if (state.startPoint) this.onMouseMove(state, e);
+    // emulate onClick
+    this.onClick(state, e);
+  },
   // Whenever a user clicks on the map, Draw will call `onClick`
   onClick: function onClick(state, e) {
     // if state.startPoint exist, means its second click

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-draw-rectangle-mode",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A custom mode for MapboxGL Draw to draw rectangles",
   "main": "dist/index.js",
   "author": "Erick Otenyo",

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,13 @@ const DrawRectangle = {
       rectangle
     };
   },
+  // support mobile taps
+  onTap: function(state, e) {
+    // emulate 'move mouse' to update feature coords
+    if (state.startPoint) this.onMouseMove(state, e);
+    // emulate onClick
+    this.onClick(state, e);
+  },
   // Whenever a user clicks on the map, Draw will call `onClick`
   onClick: function(state, e) {
     // if state.startPoint exist, means its second click


### PR DESCRIPTION
Currently tapping while on mobile doesn't trigger drawing of a rectangle. Other default modes in mapbox-draw seem to achieve this functionality with a similar technique to below.

Version also incremented